### PR TITLE
Support for Improved Audience Targeting

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,7 +52,7 @@ android {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
         
-        implementation ('com.survicate:survicate-sdk:3.0.6') {
+        implementation ('com.survicate:survicate-sdk:4.0.1') {
             exclude group: 'io.coil-kt', module: 'coil-base'
             exclude group: 'io.coil-kt', module: 'coil-gif'
             exclude group: 'io.coil-kt', module: 'coil-svg'

--- a/ios/survicate_sdk.podspec
+++ b/ios/survicate_sdk.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '12.0'
   
   s.dependency 'Flutter'
-  s.dependency 'Survicate', '3.0.4'
+  s.dependency 'Survicate', '4.0.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/lib/survicate_sdk.dart
+++ b/lib/survicate_sdk.dart
@@ -82,7 +82,7 @@ class SurvicateSdk {
   ///  * [setUserTraits], the method used to set multiple traits at once.
  static void setUserTrait(UserTrait trait) async {
     try {
-      await SurvicateSdkPlatform.instance.setUserTrait(trait.key, trait.value ?? "");
+      await SurvicateSdkPlatform.instance.setUserTrait(trait.key, trait.value);
     } catch (e) {
       // ignore
     }
@@ -95,7 +95,7 @@ class SurvicateSdk {
     try {
       Map<String, String> userTraits = {};
       for (var element in traits) {
-        userTraits[element.key] = element.value ?? "";
+        userTraits[element.key] = element.value;
       }
       await SurvicateSdkPlatform.instance.setUserTraits(userTraits);
     } catch (e) {

--- a/lib/survicate_sdk.dart
+++ b/lib/survicate_sdk.dart
@@ -1,3 +1,5 @@
+import 'package:survicate_sdk/user_trait.dart';
+
 import 'survicate_sdk_platform_interface.dart';
 
 class SurvicateSdk {
@@ -69,7 +71,7 @@ class SurvicateSdk {
     }
   }
 
-  /// Sets a single trait for the user, identified by [key], with the provided [value].
+  /// Sets a single [trait] for the user, identified by [trait.key], with the provided [trait.value].
   /// These can be arbitrary key-value pairs. Traits are persisted, so the client
   /// only needs to provide them once. Traits are sent to the system along
   /// with the user's answers to the survey. They are also used for targeting (e.g., a client
@@ -78,9 +80,9 @@ class SurvicateSdk {
   /// To change a trait, clients need to send the same key with a different value.
   /// See also:
   ///  * [setUserTraits], the method used to set multiple traits at once.
-  static void setUserTrait(String key, String value) async {
+ static void setUserTrait(UserTrait trait) async {
     try {
-      await SurvicateSdkPlatform.instance.setUserTrait(key, value);
+      await SurvicateSdkPlatform.instance.setUserTrait(trait.key, trait.value ?? "");
     } catch (e) {
       // ignore
     }
@@ -89,9 +91,13 @@ class SurvicateSdk {
   /// Sets multiple user traits at once using the provided [traits] map.
   /// See also:
   ///  * [setUserTrait], the method used to set a single trait.
-  static void setUserTraits(Map<String, String> traits) async {
+  static void setUserTraits(List<UserTrait> traits) async {
     try {
-      await SurvicateSdkPlatform.instance.setUserTraits(traits);
+      Map<String, String> userTraits = {};
+      for (var element in traits) {
+        userTraits[element.key] = element.value ?? "";
+      }
+      await SurvicateSdkPlatform.instance.setUserTraits(userTraits);
     } catch (e) {
       // ignore
     }

--- a/lib/survicate_sdk.dart
+++ b/lib/survicate_sdk.dart
@@ -88,7 +88,7 @@ class SurvicateSdk {
     }
   }
 
-  /// Sets multiple user traits at once using the provided [traits] map.
+  /// Sets multiple user traits at once using the provided [traits] list.
   /// See also:
   ///  * [setUserTrait], the method used to set a single trait.
   static void setUserTraits(List<UserTrait> traits) async {

--- a/lib/user_trait.dart
+++ b/lib/user_trait.dart
@@ -1,18 +1,16 @@
 class UserTrait {
   String key;
-  String? value;
+  String value;
 
-  UserTrait(this.key, dynamic value) {
-    if (value is DateTime) {
-      this.value = formatDateToTimeZoneIso(value);
-    } else if (value != null) {
-      this.value = value.toString();
-    } else {
-      this.value = null;
-    }
-  }
+  UserTrait.string(this.key, this.value);
 
-  String formatDateToTimeZoneIso(DateTime date) {
+  UserTrait.bool(String key, bool value): this.string(key, value.toString());
+
+  UserTrait.dateTime(String key, DateTime value) : this.string(key, _formatDateToTimeZoneIso(value));
+
+  UserTrait.num(String key, num value) : this.string(key, value.toString());
+
+  static String _formatDateToTimeZoneIso(DateTime date) {
     var offset = date.timeZoneOffset.inMinutes;
     var offsetHours = (offset.abs() / 60).floor();
     var offsetMinutes = offset.abs() % 60;

--- a/lib/user_trait.dart
+++ b/lib/user_trait.dart
@@ -1,0 +1,22 @@
+class UserTrait {
+  String key;
+  String? value;
+
+  UserTrait(this.key, dynamic value) {
+    if (value is DateTime) {
+      this.value = formatDateToTimeZoneIso(value);
+    } else if (value != null) {
+      this.value = value.toString();
+    } else {
+      this.value = null;
+    }
+  }
+
+  String formatDateToTimeZoneIso(DateTime date) {
+    var offset = date.timeZoneOffset.inMinutes;
+    var offsetHours = (offset.abs() / 60).floor();
+    var offsetMinutes = offset.abs() % 60;
+    var offsetSign = date.timeZoneOffset.isNegative ? "-" : "+";
+    return "${date.toIso8601String().substring(0, 19)}$offsetSign${offsetHours.toString().padLeft(2, '0')}:${offsetMinutes.toString().padLeft(2, '0')}";
+  }
+}


### PR DESCRIPTION
Breaking:
- Flutter SDK API no longer allows for setting user traits with String primitives. The only supported way is to use new API with UserTrait class

Updates:
- Updated native sdk dependencies