### PR TITLE
Bump GitHub Actions versions and harden workflow security

### DIFF
--- a/.github/workflows/verify-sdk-version.yml
+++ b/.github/workflows/verify-sdk-version.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Extract Survicate iOS SDK version from podspec
         id: podspec-version
@@ -36,10 +36,10 @@ jobs:
           echo "Package.swift Survicate iOS SDK version: $VERSION"
 
       - name: Compare iOS SDK versions
+        env:
+          PODSPEC_VERSION: ${{ steps.podspec-version.outputs.version }}
+          PACKAGE_VERSION: ${{ steps.package-version.outputs.version }}
         run: |
-          PODSPEC_VERSION="${{ steps.podspec-version.outputs.version }}"
-          PACKAGE_VERSION="${{ steps.package-version.outputs.version }}"
-
           echo "Podspec Survicate iOS SDK version: $PODSPEC_VERSION"
           echo "Package.swift Survicate iOS SDK version: $PACKAGE_VERSION"
 
@@ -56,8 +56,9 @@ jobs:
 
       - name: Compare tag version with pubspec.yaml
         if: inputs.tag != ''
+        env:
+          TAG_VERSION: ${{ inputs.tag }}
         run: |
-          TAG_VERSION="${{ inputs.tag }}"
           PUBSPEC_VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | tr -d '[:space:]')
 
           echo "Tag version: $TAG_VERSION"


### PR DESCRIPTION
## Summary
- Bump actions/checkout v4 → v6
- Move `${{ }}` expressions from `run:` to `env:` blocks to prevent shell injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)